### PR TITLE
Change 'Update password' conditions to remove log file flooding

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "github@phlippers.net"
 license           "MIT"
 description       "Installs Percona MySQL client and server"
 long_description  "Please refer to README.md"
-version           "0.16.3"
+version           "0.16.4"
 
 recipe "percona",                "Includes the client recipe to configure a client"
 recipe "percona::package_repo",  "Sets up the package repository and installs dependent packages"

--- a/recipes/configure_server.rb
+++ b/recipes/configure_server.rb
@@ -136,12 +136,12 @@ template percona["main_config_file"] do
 end
 
 # now let's set the root password only if this is the initial install
-unless node["percona"]["skip_passwords"]
+unless node["percona"]["skip_passwords"] || passwords.root_password.to_s.empty?
   root_pw = passwords.root_password
 
   execute "Update MySQL root password" do  # ~FC009 - `sensitive`
     command "mysqladmin --user=root --password='' password '#{root_pw}'"
-    only_if "mysqladmin --user=root --password='' version"
+    not_if "mysqladmin --user=root --password='#{root_pw}' version"
     sensitive true
   end
 end


### PR DESCRIPTION
Avoid flooding log file with:

```
2016-08-26 08:30:20 2093 [Warning] Access denied for user 'root'@'localhost' (using password: NO)
2016-08-26 08:41:27 2093 [Warning] Access denied for user 'root'@'localhost' (using password: NO)
2016-08-26 08:54:25 2093 [Warning] Access denied for user 'root'@'localhost' (using password: NO)
```
