### PR TITLE
percona: set binlog_space_limit default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ default["percona"]["server"]["binlog_ignore_db"] = []
 default["percona"]["server"]["expire_logs_days"] = 10
 default["percona"]["server"]["max_binlog_size"] = "100M"
 default["percona"]["server"]["binlog_cache_size"] = "1M"
+default["percona"]["server"]["binlog_space_limit"] = 0 
 default["percona"]["server"]["binlog_format"] = "MIXED"
 default["percona"]["server"]["log_bin"] = "master-bin"
 default["percona"]["server"]["relay_log"] = "slave-relay-bin"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -126,6 +126,7 @@ default["percona"]["server"]["binlog_do_db"] = []
 default["percona"]["server"]["binlog_ignore_db"] = []
 default["percona"]["server"]["expire_logs_days"] = 10
 default["percona"]["server"]["max_binlog_size"] = "100M"
+default["percona"]["server"]["binlog_space_limit"] = 0
 default["percona"]["server"]["binlog_cache_size"] = "1M"
 default["percona"]["server"]["binlog_format"] = "MIXED"
 default["percona"]["server"]["log_bin"] = "master-bin"

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "github@phlippers.net"
 license           "MIT"
 description       "Installs Percona MySQL client and server"
 long_description  "Please refer to README.md"
-version           "1.11.11"
+version           "1.11.12"
 
 recipe "percona",                "Includes the client recipe to configure a client"
 recipe "percona::package_repo",  "Sets up the package repository and installs dependent packages"

--- a/templates/default/my.cnf.main.erb
+++ b/templates/default/my.cnf.main.erb
@@ -355,6 +355,9 @@ log_bin          = <%= node["percona"]["server"]["datadir"] %>/mysql-bin.log
 expire_logs_days = <%= node["percona"]["server"]["expire_logs_days"] %>
 max_binlog_size  = <%= node["percona"]["server"]["max_binlog_size"] %>
 binlog_format    = <%= node["percona"]["server"]["binlog_format"] %>
+<%- if node["percona"]["version"] > "5.6" %>
+binlog_space_limit = <%= node["percona"]["server"]["binlog_space_limit"] %>
+<%- end %>
 
 <% node["percona"]["server"]["binlog_do_db"].each do |db_name| %>
 binlog-do-db     = <%= db_name %>


### PR DESCRIPTION
Based on percona [documentation](https://www.percona.com/doc/percona-server/5.7/flexibility/max_binlog_files.html)

> This option places an upper limit on the total size in bytes of all binary logs. A value of 0 means “no limit”. This is useful for a server host that has limited disk space.

by default, `binlog_space_limit` value will be `0`(unlimited) if not set, there's a need to override this value, to save more space on server storage.

