### PR TITLE
Warn in logs when password is nil

### DIFF
--- a/libraries/passwords.rb
+++ b/libraries/passwords.rb
@@ -29,6 +29,10 @@ class Chef
       end
       # password will be nil if no encrypted data bag was loaded
       # fall back to the attribute on this node
+      unless password
+        Chef::Log.warn("The password for MySQL user '#{user}' is nil.")
+      end
+
       password || default
     end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "github@phlippers.net"
 license           "MIT"
 description       "Installs Percona MySQL client and server"
 long_description  "Please refer to README.md"
-version           "5.11.11"
+version           "5.11.12"
 
 recipe "percona",                "Includes the client recipe to configure a client"
 recipe "percona::package_repo",  "Sets up the package repository and installs dependent packages"


### PR DESCRIPTION
This shouldn't happen in normal cases, but it happens.

Related: https://github.com/hostinger/infrastructure/issues/396